### PR TITLE
Fix Windows build with PHP 7.4

### DIFF
--- a/yaconf.c
+++ b/yaconf.c
@@ -544,7 +544,7 @@ PHP_MINIT_FUNCTION(yaconf)
 	const char *dirname;
 	size_t dirlen;
 	zend_class_entry ce;
-	struct zend_stat dir_sb = {0};
+	zend_stat_t dir_sb = {0};
 
 	REGISTER_INI_ENTRIES();
 
@@ -569,7 +569,7 @@ PHP_MINIT_FUNCTION(yaconf)
 		if ((ndir = php_scandir(dirname, &namelist, 0, php_alphasort)) > 0) {
 			uint32_t i;
 			unsigned char c;
-			struct zend_stat sb;
+			zend_stat_t sb;
 			zend_file_handle fh = {0};
 
 			PALLOC_HASHTABLE(ini_containers);
@@ -639,7 +639,7 @@ PHP_RINIT_FUNCTION(yaconf)
 		return SUCCESS;
 	} else {
 		char *dirname;
-		struct zend_stat dir_sb = {0};
+		zend_stat_t dir_sb = {0};
 
 		YACONF_G(last_check) = time(NULL);
 
@@ -657,7 +657,7 @@ PHP_RINIT_FUNCTION(yaconf)
 
 				if ((ndir = php_scandir(dirname, &namelist, 0, php_alphasort)) > 0) {
 					zend_string *file_key;
-					struct zend_stat sb;
+					zend_stat_t sb;
 					zend_file_handle fh = {0};
 					yaconf_filenode *node = NULL;
 


### PR DESCRIPTION
As of PHP 7.4.0, `zend_stat` is defined to `php_win32_ioutil_stat` on
Windows, so `struct zend_stat` is no longer valid.  We therefore switch
to the portable `zend_stat_t` typedef.