### PR TITLE
force log_errors=1 for PHP 8

### DIFF
--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -4,6 +4,7 @@ Check for Yaconf with long key name
 <?php if (!extension_loaded("yaconf")) print "skip"; ?>
 --INI--
 yaconf.directory={PWD}/inis/005
+log_errors=1
 --FILE--
 <?php 
 var_dump(Yaconf::has("a"));

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -4,6 +4,7 @@ Check for Yaconf with section
 <?php if (!extension_loaded("yaconf")) print "skip"; ?>
 --INI--
 yaconf.directory={PWD}/inis/006
+log_errors=1
 --FILE--
 <?php 
 var_dump(Yaconf::has("a"));


### PR DESCRIPTION
Asl error_log is Off by default.

Using **8.0.0beta4**


```
=====================================================================
PASS Check for Yaconf presence [tests/001.phpt] 
PASS Check for Yaconf [tests/002.phpt] 
PASS Check for Yaconf [tests/003.phpt] 
PASS Check for Yaconf info [tests/004.phpt] 
PASS Check for Yaconf with long key name [tests/005.phpt] 
PASS Check for Yaconf with section [tests/006.phpt] 
PASS Check for Yaconf with same keys [tests/007.phpt] 
PASS Check for Yaconf with pop entry [tests/008.phpt] 
PASS Check for INI errors [tests/009.phpt] 
PASS Check for Complex usage [tests/010.phpt] 
PASS ISSUE #19 Memory leak on foreach and reference [tests/issue19.phpt] 
PASS ISSUE #26 Segmentation fault $php_fpm_BIN --daemonize $php_opts [tests/issue26.phpt] 
=====================================================================
```